### PR TITLE
Footer divs altered for grid configuration

### DIFF
--- a/web/app/themes/coblocks-child/footer.php
+++ b/web/app/themes/coblocks-child/footer.php
@@ -19,38 +19,37 @@
 		<footer class="site-footer">
 
 			<?php get_sidebar(); ?>
-
-			<div class="site-info container center-align h6 medium smooth sans-serif-font gray" role="contentinfo">
-
-				<span class="site-title">
-					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?></a>
-				</span>
-
-				<span class="ragtag-logo">
+			<div class="primary-footer">
+				<div class="site-info container center-align h6 medium smooth sans-serif-font gray" role="contentinfo">
+					<span class="site-title">
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?></a>
+					</span>
+				</div>
+			
+				<div class="ragtag-logo">
 					<a href="https://ragtag.org/?utm_medium=web&amp;utm_source=education-leads-home&amp;utm_name=empowered-badge">
 					<img src="https://assets.ragtag.tech/empowered-by-ragtag.svg" alt="Empowered by Ragtag">
 					</a>
-				</span>
+				</div>
 
+				<div class="footer-nav">
+					<?php if ( has_nav_menu( 'footer' ) ) : ?>
+						<nav class="footer-navigation container" aria-label="<?php esc_attr_e( 'Footer Menu', '@@textdomain' ); ?>">
+
+							<?php
+							wp_nav_menu(
+								array(
+									'theme_location' => 'footer',
+									'menu_class'     => 'footer-menu sans-serif-font medium gray smooth h6 list-reset',
+									'depth'          => '1',
+								)
+							);
+							?>
+						</nav>
+					<?php endif; ?>
+				</div>
 			</div>
 
-			<?php if ( has_nav_menu( 'footer' ) ) : ?>
-
-				<nav class="footer-navigation container" aria-label="<?php esc_attr_e( 'Footer Menu', '@@textdomain' ); ?>">
-
-					<?php
-					wp_nav_menu(
-						array(
-							'theme_location' => 'footer',
-							'menu_class'     => 'footer-menu sans-serif-font medium gray smooth h6 list-reset',
-							'depth'          => '1',
-						)
-					);
-					?>
-
-				</nav>
-
-			<?php endif; ?>
 
 		</footer>
 
@@ -61,6 +60,5 @@
 	<?php wp_footer(); ?>
 
 	</body>
-
 
 </html>


### PR DESCRIPTION
Can someone double-check that this does what I think it does before merging it?

Previous issue: The footer.php file I uploaded earlier treats the nav separately from everything else, making it impossible to put all three items (site title, ragtag logo, bottom nav) into an evenly spread block.

Goal: I've tried changing the footer to put everything in the white section into an umbrella div (class="primary-footer") and apply a CSS grid to that in the customizer (not seen here). I've put each of the three footer items in its own div (site title, ragtag logo, bottom nav) directly in the umbrella div, which should make them the three grid items I want.